### PR TITLE
Make kobuki_msgs build for ROS2 (and Windows 10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,32 +1,35 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(kobuki_msgs)
-find_package(catkin REQUIRED COMPONENTS std_msgs actionlib_msgs message_generation)
 
-add_message_files(DIRECTORY msg
-                      FILES BumperEvent.msg
-                            CliffEvent.msg
-                            DigitalOutput.msg
-                            ExternalPower.msg
-                            Led.msg
-                            PowerSystemEvent.msg
-                            SensorState.msg
-                            VersionInfo.msg
-                            ControllerInfo.msg
-                            ButtonEvent.msg
-                            DigitalInputEvent.msg
-                            DockInfraRed.msg
-                            KeyboardInput.msg
-                            MotorPower.msg
-                            RobotStateEvent.msg
-                            Sound.msg
-                            ScanAngle.msg
-                            WheelDropEvent.msg
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+                            msg/BumperEvent.msg
+                            msg/CliffEvent.msg
+                            #msg/DigitalOutput.msg
+                            #msg/ExternalPower.msg
+                            msg/Led.msg
+                            msg/PowerSystemEvent.msg
+                            #msg/SensorState.msg
+                            #msg/VersionInfo.msg
+                            #msg/ControllerInfo.msg
+                            msg/ButtonEvent.msg
+                            msg/DigitalInputEvent.msg
+                            #msg/DockInfraRed.msg
+                            #msg/KeyboardInput.msg
+                            #msg/MotorPower.msg
+                            msg/RobotStateEvent.msg
+                            #msg/Sound.msg
+                            #msg/ScanAngle.msg
+                            msg/WheelDropEvent.msg
                  )
 
-add_action_files(DIRECTORY action
-                     FILES AutoDocking.action
-                )
+#add_action_files(DIRECTORY action
+#                     FILES AutoDocking.action
+#                )
 
-generate_messages(DEPENDENCIES std_msgs actionlib_msgs)
+ament_export_dependencies(rosidl_default_runtime)
 
-catkin_package(CATKIN_DEPENDS message_runtime std_msgs actionlib_msgs)
+ament_package()

--- a/msg/ButtonEvent.msg
+++ b/msg/ButtonEvent.msg
@@ -3,9 +3,9 @@
 # Note that, despite buttons field on SensorState messages, state field is not a
 # bitmask, but the new state of a single button.
 
-uint8 Button0 = 0
-uint8 Button1 = 1
-uint8 Button2 = 2
+uint8 BUTTON0 = 0
+uint8 BUTTON1 = 1
+uint8 BUTTON2 = 2
 
 uint8 RELEASED = 0
 uint8 PRESSED  = 1

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,6 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>kobuki_msgs</name>
   <version>0.7.0</version>
   <description>
@@ -13,14 +15,21 @@
   <url type="website">http://ros.org/wiki/kobuki_msgs</url>
   <url type="repository">https://github.com/yujinrobot/kobuki_msgs</url>
   <url type="bugtracker">https://github.com/yujinrobot/kobuki_msgs/issues</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <!--<build_depend>actionlib_msgs</build_depend>-->
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <!--<exec_depend>actionlib_msgs</exec_depend>-->
+
+  <exec_depend>ament_cmake</exec_depend>
   
-  <buildtool_depend>catkin</buildtool_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
-  <build_depend>std_msgs</build_depend>
-  <build_depend>actionlib_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
-
-  <run_depend>std_msgs</run_depend>
-  <run_depend>actionlib_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
Should go to a ROS2 branch.

This is a part of an effort to port Kobuki and Turtlebot2 to ROS2 and Windows 10.
